### PR TITLE
feat(#4): interestField 다중 선택 가능하도록 수정

### DIFF
--- a/etf/src/main/java/com/realthon/etf/user/domain/User.java
+++ b/etf/src/main/java/com/realthon/etf/user/domain/User.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -42,9 +43,11 @@ public class User {
     @Column(nullable = false, length = 50)
     private String major;
 
+    @ElementCollection
+    @CollectionTable(name = "user_interest_field")
     @Enumerated(EnumType.STRING)
-    @Column(name = "interest_field", nullable = false)
-    private InterestField interestField;
+    @Column(name = "interest_field")
+    private Set<InterestField> interestFields;
 
     @Column(nullable = true)
     private Long intervalDays = 2L;
@@ -65,7 +68,7 @@ public class User {
 
     @Builder
     public User(String loginId, String password, String username, String phoneNumber, String email,
-                String school, String major, InterestField interestField, Long intervalDays, LocalTime alarmTime) {
+                String school, String major, Set<InterestField> interestFields, Long intervalDays, LocalTime alarmTime) {
         this.loginId = loginId;
         this.password = password;
         this.username = username;
@@ -73,7 +76,7 @@ public class User {
         this.email = email;
         this.school = school;
         this.major = major;
-        this.interestField = interestField;
+        this.interestFields = interestFields;
         this.intervalDays = intervalDays;
         this.alarmTime = alarmTime;
     }
@@ -83,7 +86,7 @@ public class User {
                               String email,
                               String school,
                               String major,
-                              InterestField interestField,
+                              Set<InterestField> interestFields,
                               Long intervalDays,
                               LocalTime alarmTime) {
 
@@ -92,7 +95,7 @@ public class User {
         if (email != null)         this.email = email;
         if (school != null)        this.school = school;
         if (major != null)         this.major = major;
-        if (interestField != null) this.interestField = interestField;
+        if (interestFields != null) this.interestFields = interestFields;
         if (intervalDays != null)  this.intervalDays = intervalDays;
         if (alarmTime != null)     this.alarmTime = alarmTime;
     }

--- a/etf/src/main/java/com/realthon/etf/user/dto/request/CreateUserRequest.java
+++ b/etf/src/main/java/com/realthon/etf/user/dto/request/CreateUserRequest.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -36,8 +37,8 @@ public class CreateUserRequest {
     @Size(max = 50)
     private String major;
 
-    @NotNull
-    private InterestField interestField;
+    @NotEmpty
+    private Set<InterestField> interestFields;
 
     @Min(1)
     private Long intervalDays;
@@ -53,7 +54,7 @@ public class CreateUserRequest {
                 .email(getEmail())
                 .school(getSchool())
                 .major(getMajor())
-                .interestField(getInterestField())
+                .interestFields(getInterestFields())
                 .intervalDays(getIntervalDays())
                 .alarmTime(getAlarmTime())
                 .build();

--- a/etf/src/main/java/com/realthon/etf/user/dto/request/UpdateUserRequest.java
+++ b/etf/src/main/java/com/realthon/etf/user/dto/request/UpdateUserRequest.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -29,7 +30,7 @@ public class UpdateUserRequest {
     @Size(max = 50)
     private String major;
 
-    private InterestField interestField;
+    private Set<InterestField> interestFields;
 
     @Min(1)
     private Long intervalDays;

--- a/etf/src/main/java/com/realthon/etf/user/dto/response/UserResponse.java
+++ b/etf/src/main/java/com/realthon/etf/user/dto/response/UserResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 @Getter
 @Builder
@@ -18,7 +19,7 @@ public class UserResponse {
     private String email;
     private String school;
     private String major;
-    private InterestField interestField;
+    private Set<InterestField> interestFields;
     private Long intervalDays;
     private LocalTime alarmTime;
 
@@ -31,7 +32,7 @@ public class UserResponse {
                 .email(user.getEmail())
                 .school(user.getSchool())
                 .major(user.getMajor())
-                .interestField(user.getInterestField())
+                .interestFields(user.getInterestFields())
                 .intervalDays(user.getIntervalDays())
                 .alarmTime(user.getAlarmTime())
                 .build();

--- a/etf/src/main/java/com/realthon/etf/user/service/UserService.java
+++ b/etf/src/main/java/com/realthon/etf/user/service/UserService.java
@@ -68,7 +68,7 @@ public class UserService {
                 request.getEmail(),
                 request.getSchool(),
                 request.getMajor(),
-                request.getInterestField(),
+                request.getInterestFields(),
                 request.getIntervalDays(),
                 request.getAlarmTime()
         );


### PR DESCRIPTION
## 📍 연관 이슈
close #4 

## 📝 작업 내용
- [x] 유저 interestField를 기존 단일 enum → 다중 enum 마이그레이션 SQL로 변경

## 📸 스크린샷 / 결과 (선택)
<img width="801" height="636" alt="image" src="https://github.com/user-attachments/assets/58243433-022d-4f3c-b6a9-711b43b60208" />

