### PR TITLE
feat(#40): target-url 관련 api 및 

### DIFF
--- a/etf/src/main/java/com/realthon/etf/ai/controller/AiCrawlerController.java
+++ b/etf/src/main/java/com/realthon/etf/ai/controller/AiCrawlerController.java
@@ -37,11 +37,10 @@ public class AiCrawlerController {
      * 2) request body에서 targetUrl만 받아서
      * 3) aiCrawlerService.createRequestAndDispatch(userId, targetUrl)로 위임
      */
-    @PostMapping({"/crawl/request"})
-    public ResponseEntity<?> requestCrawl(@RequestBody CrawlTriggerRequest request,
-                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return ResponseEntity.ok(aiCrawlerService.createRequestAndDispatch(userId, request.getTargetUrl()));
+    @PostMapping("/crawl/request")
+    public ResponseEntity<Void> requestCrawl(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        aiCrawlerService.createRequestAndDispatchWithTargetUrls(userDetails.getUserId());
+        return ResponseEntity.ok().build();
     }
 
     /*

--- a/etf/src/main/java/com/realthon/etf/ai/dto/request/AiCallbackRequest.java
+++ b/etf/src/main/java/com/realthon/etf/ai/dto/request/AiCallbackRequest.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
 import java.time.Instant;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -12,8 +13,7 @@ import java.time.Instant;
 public class AiCallbackRequest {
 
     private String status;
-    private Double relevanceScore;
-    private DataDto data;
+    private List<DataDto> data;
 
     @Getter
     @NoArgsConstructor

--- a/etf/src/main/java/com/realthon/etf/ai/dto/request/AiCrawlRequest.java
+++ b/etf/src/main/java/com/realthon/etf/ai/dto/request/AiCrawlRequest.java
@@ -2,6 +2,7 @@ package com.realthon.etf.ai.dto.request;
 
 import lombok.*;
 
+import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -11,7 +12,7 @@ import java.util.Set;
 public class AiCrawlRequest {
 
     private String userId;
-    private String targetUrl;
+    private List<String> targetUrls;
     private UserProfile userProfile;
     private String summary;
 

--- a/etf/src/main/java/com/realthon/etf/ai/service/AiCallbackService.java
+++ b/etf/src/main/java/com/realthon/etf/ai/service/AiCallbackService.java
@@ -29,88 +29,70 @@ public class AiCallbackService {
      * 2. 이미 처리된 요청인지 검사(멱등성 보장)
      * 3. AI 응답 상태 확인(SUCCESS / FAILED)
      * 4. 성공 시 AiRequest 상태 업데이트 + Notification 생성
+     *
+     * 처리 원칙:
+     * - requestId = 요청 단위 (AiRequest 1건)
+     * - data[] = 결과 단위 (Notification N건)
      */
     @Transactional
     public void handleCallback(String requestId, AiCallbackRequest request) {
 
         AiRequest req = aiRequestRepository.findByRequestId(requestId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.AI_REQUEST_NOT_FOUND));
+
+        // 멱등성 보장 (이미 처리된 요청이면 무시)
         if (req.getStatus() != AiRequestStatus.PENDING) {
-            throw new CustomException(ExceptionCode.AI_ALREADY_COMPLETED);
+            return;
         }
 
-        // AI 응답이 SUCCESS가 아닌 경우 → 실패로 처리하고 종료
+        // AI 전체 실패
         if (!"SUCCESS".equalsIgnoreCase(request.getStatus())) {
             req.markFailed(request.getStatus());
             return;
         }
-        // SUCCESS인데 실제 결과 데이터가 없는 경우 → 비정상 응답으로 간주하여 실패 처리
-        if (request.getData() == null) {
-            req.markFailed("AI data가 비어있음");
+
+        // SUCCESS지만 결과 없음 → 비정상
+        if (request.getData() == null || request.getData().isEmpty()) {
+            req.markFailed("AI 결과 데이터가 비어있음");
             return;
         }
 
-        // AI가 보내준 실제 분석 결과
-        var d = request.getData();
+        // 대표 결과 1건 선택 (첫 번째 결과)
+        AiCallbackRequest.DataDto first = request.getData().get(0);
 
-        // AiRequest 엔티티를 SUCCESS 상태로 업데이트 → AI가 분석한 결과 메타데이터를 DB에 저장
+        // AiRequest 요청 메타 업데이트
         req.markSuccess(
-                request.getRelevanceScore(),
-                d.getCategory(),
-                d.getTitle(),
-                d.getSourceName(),
-                d.getSummary(),
-                d.getOriginalUrl(),
-                d.getTimestamp()
+                null,
+                first.getCategory(),
+                first.getTitle(),
+                first.getSourceName(),
+                first.getSummary(),
+                first.getOriginalUrl(),
+                first.getTimestamp()
         );
 
-        // 사용자에게 보여줄 알림(Notification) 정보 구성
-        String title = (d.getTitle() != null && !d.getTitle().isBlank())
-                ? d.getTitle()
-                : "추천 공고 도착함";
+        // 결과 개수만큼 Notification 생성
+        for (AiCallbackRequest.DataDto d : request.getData()) {
 
-        String content = buildContent(request.getRelevanceScore(), d);
+            Notification notification = Notification.builder()
+                    .user(req.getUser())
+                    .category(d.getCategory())
+                    .title(
+                            (d.getTitle() != null && !d.getTitle().isBlank())
+                                    ? d.getTitle()
+                                    : "추천 결과 도착함"
+                    )
+                    .sourceName(d.getSourceName())
+                    .summary(d.getSummary())
+                    .originalUrl(
+                            (d.getOriginalUrl() != null && !d.getOriginalUrl().isBlank())
+                                    ? d.getOriginalUrl()
+                                    : req.getTargetUrl()
+                    )
+                    .createdAt(LocalDateTime.now())
+                    .build();
 
-        String url = (d.getOriginalUrl() != null && !d.getOriginalUrl().isBlank())
-                ? d.getOriginalUrl()
-                : req.getTargetUrl();
-
-        // Notification 엔티티 생성
-        Notification notification = Notification.builder()
-                .user(req.getUser())
-                .category(d.getCategory())
-                .title(d.getTitle())
-                .sourceName(d.getSourceName())
-                .summary(d.getSummary())
-                .originalUrl(d.getOriginalUrl())
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        notificationRepository.save(notification);
-    }
-
-    /**
-     * Notification에 들어갈 알림 본문(content)을 생성하는 유틸 메서드
-     *
-     * AI 점수 및 요약 정보를 사람이 읽기 쉬운 문자열로 구성함
-     */
-    private String buildContent(Double relevanceScore, AiCallbackRequest.DataDto d) {
-
-        // relevanceScore가 없는 경우를 대비한 기본 처리
-        String score = (relevanceScore == null)
-                ? "없음"
-                : String.format("%.2f", relevanceScore);
-
-        // 각 필드에 대해 null 방어 처리
-        String category = (d.getCategory() == null) ? "미분류" : d.getCategory();
-        String source = (d.getSourceName() == null) ? "출처 없음" : d.getSourceName();
-        String summary = (d.getSummary() == null) ? "요약 없음" : d.getSummary();
-
-        // 알림 메시지 포맷 구성
-        return """
-                [%s] %s
-                relevanceScore=%s
-                %s
-                """.formatted(category, source, score, summary).trim();
+            notificationRepository.save(notification);
+        }
     }
 }

--- a/etf/src/main/java/com/realthon/etf/ai/service/AiCrawlerService.java
+++ b/etf/src/main/java/com/realthon/etf/ai/service/AiCrawlerService.java
@@ -6,16 +6,18 @@ import com.realthon.etf.ai.dto.request.AiCrawlRequest;
 import com.realthon.etf.ai.repository.AiRequestRepository;
 import com.realthon.etf.global.exception.CustomException;
 import com.realthon.etf.global.exception.ExceptionCode;
+import com.realthon.etf.targetUrl.domain.TargetUrl;
+import com.realthon.etf.targetUrl.repository.TargetUrlRepository;
 import com.realthon.etf.user.domain.User;
 import com.realthon.etf.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -28,6 +30,7 @@ public class AiCrawlerService {
     private final UserRepository userRepository;
     private final AiRequestRepository aiRequestRepository;
     private final AiCrawlerClient aiCrawlerClient;
+    private final TargetUrlRepository targetUrlRepository;
 
     @Value("${ai.crawler.callback-auth-token:}")
     private String callbackAuthToken;
@@ -36,92 +39,92 @@ public class AiCrawlerService {
     private String publicBaseUrl;
 
     /**
-     * [동기] 요청 생성 + 저장(PENDING) + AI 호출
+     * [동기] 사용자에게 저장된 targetUrl 리스트를 한 번에 AI로 전송
+     * - requestId = 배치 단위
+     * - AiRequest = 1건
+     * - callback = 1번
      */
     @Transactional
-    public String createRequestAndDispatch(Long userId, String targetUrl) {
+    public String createRequestAndDispatchWithTargetUrls(Long userId) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
 
+        // targetUrl 리스트 조회
+        List<String> targetUrls = targetUrlRepository.findAllByUser_UserId(userId)
+                .stream()
+                .map(TargetUrl::getTargetUrl)
+                .toList();
+
+        if (targetUrls.isEmpty()) {
+            throw new CustomException(ExceptionCode.TARGET_URL_NOT_FOUND);
+        }
+
+        // requestId 생성 (배치 단위)
         String requestId = UUID.randomUUID().toString();
-        AiRequest saved = aiRequestRepository.save(new AiRequest(requestId, user, targetUrl));
-        AiCrawlRequest aiReq = buildAiRequest(user, requestId, targetUrl);
 
-        aiCrawlerClient.requestCrawl(aiReq);
+        // AiRequest 저장 (대표 URL만 저장)
+        AiRequest aiRequest = new AiRequest(
+                requestId,
+                user,
+                targetUrls.get(0)
+        );
+        aiRequestRepository.save(aiRequest);
 
-        return saved.getRequestId();
+        // AI 요청 DTO 생성
+        AiCrawlRequest request = buildAiRequest(user, requestId, targetUrls);
+
+        // AI 서버 호출
+        aiCrawlerClient.requestCrawl(request);
+
+        return requestId;
     }
 
     /**
-     * User -> AI 전송 DTO로 변환함 (+ callbackUrl 생성)
+     * User → AI 요청 DTO 변환
      */
-    private AiCrawlRequest buildAiRequest(User user, String requestId, String targetUrl) {
+    private AiCrawlRequest buildAiRequest(User user, String requestId, List<String> targetUrls) {
 
-        // interestFields enum -> string set
-        Set<String> interestFields = (user.getInterestFields() == null) ? null
+        Set<String> interestFields = (user.getInterestFields() == null)
+                ? null
                 : user.getInterestFields().stream()
                 .map(Enum::name)
                 .collect(Collectors.toSet());
 
-        String alarmTimeStr = (user.getAlarmTime() == null) ? null
+        String alarmTimeStr = (user.getAlarmTime() == null)
+                ? null
                 : user.getAlarmTime().format(DateTimeFormatter.ISO_LOCAL_TIME);
 
-        AiCrawlRequest.UserProfile profile = new AiCrawlRequest.UserProfile(
-                user.getUsername(),
-                user.getPhoneNumber(),
-                user.getSchool(),
-                user.getMajor(),
-                interestFields,
-                user.getIntervalDays(),
-                alarmTimeStr
-        );
+        AiCrawlRequest.UserProfile profile =
+                AiCrawlRequest.UserProfile.builder()
+                        .username(user.getUsername())
+                        .phoneNumber(user.getPhoneNumber())
+                        .school(user.getSchool())
+                        .major(user.getMajor())
+                        .interestFields(interestFields)
+                        .intervalDays(user.getIntervalDays())
+                        .alarmTime(alarmTimeStr)
+                        .build();
 
-        // resume summary
         String summary = (user.getResumeSummary() != null)
                 ? user.getResumeSummary().getSummary()
                 : null;
 
-        String callbackUrl = (publicBaseUrl + "/ai/callback/" + requestId).trim();
+        String callbackUrl = publicBaseUrl + "/ai/callback/" + requestId;
 
-        AiCrawlRequest.CallbackDto callback = new AiCrawlRequest.CallbackDto(
-                true,
-                callbackUrl,
-                callbackAuthToken
-        );
+        AiCrawlRequest.CallbackDto callback =
+                AiCrawlRequest.CallbackDto.builder()
+                        .enabled(true)
+                        .callbackUrl(callbackUrl)
+                        .authToken(callbackAuthToken)
+                        .build();
 
         return AiCrawlRequest.builder()
                 .userId(String.valueOf(user.getUserId()))
-                .targetUrl(targetUrl)
+                .targetUrls(targetUrls)
                 .userProfile(profile)
                 .summary(summary)
                 .callback(callback)
                 .build();
-    }
-
-    /**
-     * [비동기] AI 호출 (스케줄링/배치에서 쓰기 좋음)
-     * - 실패해도 메인 로직 롤백 없이, ai_requests에 FAILED만 찍고 끝냄
-     */
-    @Async("aiExecutor")
-    @Transactional(noRollbackFor = Exception.class)
-    public void dispatchToAiAsync(Long userId, String targetUrl) {
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
-
-        String requestId = UUID.randomUUID().toString();
-        aiRequestRepository.save(new AiRequest(requestId, user, targetUrl));
-
-        AiCrawlRequest request = buildAiRequest(user, requestId, targetUrl);
-
-        try {
-            aiCrawlerClient.requestCrawl(request);
-        } catch (Exception e) {
-            log.error("[AI_CRAWLER] dispatch failed. requestId={}, userId={}", requestId, userId, e);
-
-            AiRequest req = aiRequestRepository.findByRequestId(requestId).orElse(null);
-            if (req != null) req.markFailed("AI 크롤러 호출 실패함");
-        }
     }
 }

--- a/etf/src/main/java/com/realthon/etf/global/exception/ClientExceptionCode.java
+++ b/etf/src/main/java/com/realthon/etf/global/exception/ClientExceptionCode.java
@@ -28,6 +28,10 @@ public enum ClientExceptionCode {
     RESUME_FILE_REQUIRED,
     RESUME_SUMMARY_NOT_FOUND,
 
+    // 내 웹 사이트
+    TARGET_URL_NOT_FOUND,
+    TARGET_URL_DUPLICATED,
+
     // 알림
     NOTIFICATION_NOT_FOUND,
 

--- a/etf/src/main/java/com/realthon/etf/global/exception/ExceptionCode.java
+++ b/etf/src/main/java/com/realthon/etf/global/exception/ExceptionCode.java
@@ -33,6 +33,10 @@ public enum ExceptionCode {
     RESUME_FILE_REQUIRED(HttpStatus.BAD_REQUEST, ClientExceptionCode.RESUME_FILE_REQUIRED, "이력서 PDF 파일을 업로드해 주세요."),
     RESUME_SUMMARY_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.RESUME_SUMMARY_NOT_FOUND, "이력서 요약본이 없습니다. 먼저 이력서 PDF 업로드를 해주세요."),
 
+    // 내 웹사이트
+    TARGET_URL_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.TARGET_URL_NOT_FOUND, "존재하지 않는 내 웹 사이트입니다."),
+    TARGET_URL_DUPLICATED(HttpStatus.CONFLICT, ClientExceptionCode.TARGET_URL_DUPLICATED, "이미 등록한 웹 사이트입니다."),
+
     // 알림
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.NOTIFICATION_NOT_FOUND, "존재하지 않는 알림입니다."),
 

--- a/etf/src/main/java/com/realthon/etf/targetUrl/controller/TargetUrlController.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/controller/TargetUrlController.java
@@ -1,0 +1,61 @@
+package com.realthon.etf.targetUrl.controller;
+
+import com.realthon.etf.targetUrl.dto.request.TargetUrlRequest;
+import com.realthon.etf.targetUrl.dto.response.TargetUrlListResponse;
+import com.realthon.etf.targetUrl.dto.response.TargetUrlResponse;
+import com.realthon.etf.targetUrl.service.TargetUrlService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/me/target-urls")
+public class TargetUrlController {
+
+    private final TargetUrlService targetUrlService;
+
+    /*
+    target-url 등록
+    POST /users/me/target-urls
+     */
+    @PostMapping
+    public ResponseEntity<TargetUrlResponse> create(@AuthenticationPrincipal UserDetails userDetails,
+                                                    @Valid @RequestBody TargetUrlRequest request) {
+        return ResponseEntity.ok(targetUrlService.create(userDetails.getUsername(), request));
+    }
+
+    /*
+    target-url 수정
+    PATCH /users/me/target-urls/{targetUrlId}
+     */
+    @PatchMapping("/{targetUrlId}")
+    public ResponseEntity<TargetUrlResponse> update(@AuthenticationPrincipal UserDetails userDetails,
+                                                    @PathVariable Long targetUrlId,
+                                                    @Valid @RequestBody TargetUrlRequest request) {
+        return ResponseEntity.ok(targetUrlService.update(userDetails.getUsername(), targetUrlId, request));
+    }
+
+    /*
+    target-url 삭제
+    DELETE /users/me/target-urls/{targetUrlId}
+     */
+    @DeleteMapping("/{targetUrlId}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal UserDetails userDetails,
+                                       @PathVariable Long targetUrlId) {
+        targetUrlService.delete(userDetails.getUsername(), targetUrlId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /*
+    target-url 리스트 조회
+    GET /users/me/target-urls
+     */
+    @GetMapping
+    public ResponseEntity<TargetUrlListResponse> list(@AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(targetUrlService.list(userDetails.getUsername()));
+    }
+}

--- a/etf/src/main/java/com/realthon/etf/targetUrl/domain/TargetUrl.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/domain/TargetUrl.java
@@ -1,0 +1,34 @@
+package com.realthon.etf.targetUrl.domain;
+
+import com.realthon.etf.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "target_urls")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TargetUrl {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long targetUrlId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "target_url", nullable = false, length = 1000)
+    private String targetUrl;
+
+    @Builder
+    public TargetUrl(User user, String targetUrl) {
+        this.user = user;
+        this.targetUrl = targetUrl;
+    }
+
+    public void updateUrl(String newUrl) {
+        this.targetUrl = newUrl;
+    }
+}

--- a/etf/src/main/java/com/realthon/etf/targetUrl/dto/request/TargetUrlRequest.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/dto/request/TargetUrlRequest.java
@@ -1,0 +1,13 @@
+package com.realthon.etf.targetUrl.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import org.hibernate.validator.constraints.URL;
+
+@Getter
+public class TargetUrlRequest {
+
+    @NotBlank(message = "targetUrl은 필수임")
+    @URL(message = "올바른 URL 형식이 아님")
+    private String targetUrl;
+}

--- a/etf/src/main/java/com/realthon/etf/targetUrl/dto/response/TargetUrlListResponse.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/dto/response/TargetUrlListResponse.java
@@ -1,0 +1,21 @@
+package com.realthon.etf.targetUrl.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TargetUrlListResponse {
+
+    private long totalCount;
+    private List<TargetUrlResponse> targetUrls;
+
+    public static TargetUrlListResponse of(long totalCount, List<TargetUrlResponse> targetUrls) {
+        return TargetUrlListResponse.builder()
+                .totalCount(totalCount)
+                .targetUrls(targetUrls)
+                .build();
+    }
+}

--- a/etf/src/main/java/com/realthon/etf/targetUrl/dto/response/TargetUrlResponse.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/dto/response/TargetUrlResponse.java
@@ -1,0 +1,20 @@
+package com.realthon.etf.targetUrl.dto.response;
+
+import com.realthon.etf.targetUrl.domain.TargetUrl;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TargetUrlResponse {
+
+    private Long targetUrlId;
+    private String targetUrl;
+
+    public static TargetUrlResponse from(TargetUrl entity) {
+        return TargetUrlResponse.builder()
+                .targetUrlId(entity.getTargetUrlId())
+                .targetUrl(entity.getTargetUrl())
+                .build();
+    }
+}

--- a/etf/src/main/java/com/realthon/etf/targetUrl/repository/TargetUrlRepository.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/repository/TargetUrlRepository.java
@@ -13,4 +13,5 @@ public interface TargetUrlRepository extends JpaRepository<TargetUrl, Long> {
     Optional<TargetUrl> findByTargetUrlIdAndUser_UserId(Long targetUrlId, Long userId);
     List<TargetUrl> findAllByUser_UserIdOrderByTargetUrlIdDesc(Long userId);
     long countByUser_UserId(Long userId);
+    List<TargetUrl> findAllByUser_UserId(Long userId);
 }

--- a/etf/src/main/java/com/realthon/etf/targetUrl/repository/TargetUrlRepository.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/repository/TargetUrlRepository.java
@@ -1,0 +1,16 @@
+package com.realthon.etf.targetUrl.repository;
+
+import com.realthon.etf.targetUrl.domain.TargetUrl;
+import com.realthon.etf.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TargetUrlRepository extends JpaRepository<TargetUrl, Long> {
+
+    boolean existsByUser_UserIdAndTargetUrl(Long userId, String targetUrl);
+    Optional<TargetUrl> findByTargetUrlIdAndUser_UserId(Long targetUrlId, Long userId);
+    List<TargetUrl> findAllByUser_UserIdOrderByTargetUrlIdDesc(Long userId);
+    long countByUser_UserId(Long userId);
+}

--- a/etf/src/main/java/com/realthon/etf/targetUrl/service/TargetUrlService.java
+++ b/etf/src/main/java/com/realthon/etf/targetUrl/service/TargetUrlService.java
@@ -1,0 +1,114 @@
+package com.realthon.etf.targetUrl.service;
+
+import com.realthon.etf.global.exception.CustomException;
+import com.realthon.etf.global.exception.ExceptionCode;
+import com.realthon.etf.targetUrl.domain.TargetUrl;
+import com.realthon.etf.targetUrl.dto.request.TargetUrlRequest;
+import com.realthon.etf.targetUrl.dto.response.TargetUrlListResponse;
+import com.realthon.etf.targetUrl.dto.response.TargetUrlResponse;
+import com.realthon.etf.targetUrl.repository.TargetUrlRepository;
+import com.realthon.etf.user.domain.User;
+import com.realthon.etf.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TargetUrlService {
+
+    private final TargetUrlRepository targetUrlRepository;
+    private final UserRepository userRepository;
+
+    /*
+    target-url 등록
+     */
+    public TargetUrlResponse create(String loginId, TargetUrlRequest request) {
+        User user = getUserByLoginId(loginId);
+        String url = normalize(request.getTargetUrl());
+
+        if (targetUrlRepository.existsByUser_UserIdAndTargetUrl(user.getUserId(), url)) {
+            throw new CustomException(ExceptionCode.TARGET_URL_DUPLICATED);
+        }
+
+        TargetUrl saved = targetUrlRepository.save(
+                TargetUrl.builder()
+                        .user(user)
+                        .targetUrl(url)
+                        .build()
+        );
+
+        return TargetUrlResponse.from(saved);
+    }
+
+    /*
+    target-url 수정
+     */
+    public TargetUrlResponse update(String loginId, Long targetUrlId, TargetUrlRequest request) {
+        User user = getUserByLoginId(loginId);
+
+        TargetUrl targetUrl = targetUrlRepository
+                .findByTargetUrlIdAndUser_UserId(targetUrlId, user.getUserId())
+                .orElseThrow(() -> new CustomException(ExceptionCode.TARGET_URL_NOT_FOUND));
+
+        String newUrl = normalize(request.getTargetUrl());
+
+        if (!targetUrl.getTargetUrl().equals(newUrl)
+                && targetUrlRepository.existsByUser_UserIdAndTargetUrl(user.getUserId(), newUrl)) {
+            throw new CustomException(ExceptionCode.TARGET_URL_DUPLICATED);
+        }
+
+        targetUrl.updateUrl(newUrl);
+        return TargetUrlResponse.from(targetUrl);
+    }
+
+    /*
+    target-url 삭제
+     */
+    public void delete(String loginId, Long targetUrlId) {
+        User user = getUserByLoginId(loginId);
+
+        TargetUrl targetUrl = targetUrlRepository
+                .findByTargetUrlIdAndUser_UserId(targetUrlId, user.getUserId())
+                .orElseThrow(() -> new CustomException(ExceptionCode.TARGET_URL_NOT_FOUND));
+
+        targetUrlRepository.delete(targetUrl);
+    }
+
+    /*
+    target-url 리스트 조회
+     */
+    @Transactional(readOnly = true)
+    public TargetUrlListResponse list(String loginId) {
+        User user = getUserByLoginId(loginId);
+
+        List<TargetUrlResponse> items = targetUrlRepository
+                .findAllByUser_UserIdOrderByTargetUrlIdDesc(user.getUserId())
+                .stream()
+                .map(TargetUrlResponse::from)
+                .toList();
+
+        long totalCount = targetUrlRepository.countByUser_UserId(user.getUserId());
+
+        return TargetUrlListResponse.of(totalCount, items);
+    }
+
+    // 공통 사용자 조회 로직
+    private User getUserByLoginId(String loginId) {
+        return userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+    }
+
+    // URL 정규화
+    private String normalize(String url) {
+        if (url == null) return null;
+        String trimmed = url.trim();
+        if (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+}

--- a/etf/src/main/java/com/realthon/etf/user/domain/User.java
+++ b/etf/src/main/java/com/realthon/etf/user/domain/User.java
@@ -2,6 +2,7 @@ package com.realthon.etf.user.domain;
 
 import com.realthon.etf.notification.domain.Notification;
 import com.realthon.etf.resume.domain.UserResumeSummary;
+import com.realthon.etf.targetUrl.domain.TargetUrl;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
@@ -63,6 +64,9 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TargetUrl> targetUrls = new ArrayList<>();
 
     @PrePersist
     @PreUpdate


### PR DESCRIPTION
## 📍 연관 이슈
close #40 

## 📝 작업 내용
- [x] targetUrl 등록/수정/삭제/조회 CRUD api 구현
- [x] targetUrl 관련 예외 처리 및 에러 핸들링
- [x] AI 콜백 응답 구조를 단일 결과에서 다중 결과(data 리스트) 처리 방식으로 변경
- [x] AI 콜백 처리 시 결과 개수만큼 Notification 생성하도록 수정
- [x] AI 요청 시 사용자가 저장한 targetUrl 목록을 단건이 아닌 리스트 배치 형태로 전송하도록 구조 변경
- [x] relevanceScore 필드 제거에 따라 AI 콜백 DTO 및 서비스 로직 정리함

## 📸 스크린샷 / 결과 (선택)
- targetUrl 등록
  <img width="1456" height="766" alt="image" src="https://github.com/user-attachments/assets/5c94d08a-696f-4351-93d3-54514c185ac8" />
- targetUrl 수정
  <img width="1488" height="850" alt="image" src="https://github.com/user-attachments/assets/6b40fa6a-ec0a-498c-a41c-3a57ffbecb9f" />
- targetUrl 삭제
  <img width="1480" height="634" alt="image" src="https://github.com/user-attachments/assets/96a10aba-f028-46f7-8f8e-4df3cc6f813d" />
- targetUrl 리스트 조회
  <img width="1486" height="1108" alt="image" src="https://github.com/user-attachments/assets/bbb2c556-afc4-4bf3-bf2e-9167f71d07af" />

## 🔗 참고사항
- 현재 크롤러한테 전달하고 있는 JSON 구조입니다.
```json
{
  "userId": "user_12345",
  "targetUrls": [
    "https://www.sogang.ac.kr/ko/home",
    "https://www.korea.ac.kr/sites/ko/index.do",
    "https://www.ewha.ac.kr/ewha/index.do"
  ],
  "userProfile": {
    "username": "양은서",
    "phoneNumber": "010-1234-5678",
    "school": "이화여자대학교",
    "major": "컴퓨터공학과",
    "interestFields": [
      "BACKEND",
      "AI"
    ],
    "intervalDays": 2,
    "alarmTime": "09:00"
  },
  "summary": "Java/Spring 기반 백엔드 개발자 신입 포지션 희망",
  "callback": {
    "enabled": true,
    "callbackUrl": "https://api.allyeojujob.com/ai/callback",
    "authToken": "AI_CALLBACK_SECRET"
  }
}
```
- 콜백 body는 크롤러 결과 data를 리스트 형태로 한 번 받고 각 data를 db에 저장하는 로직으로 구현하였습니다.